### PR TITLE
Real Time Debug for Pythonの拡張機能名称が間違っていた

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Quick Start
 | --------------------------------------------- | -------------------------- |
 | Japanese Language Pack for Visual Studio Code | Japanese Language Display  |
 | Python                                        | Can Use Python             |
-| Apel for python                               | Real Time Debug for Python |
+| AREPL for python                              | Real Time Debug for Python |
 
 ## Python-Package
 


### PR DESCRIPTION
READMEに記述されていた拡張機能Apel for pythonは、AREPL for pythonの間違いだと思います。
おそらく次の拡張機能を指していると思うので訂正しました。
https://marketplace.visualstudio.com/items?itemName=almenon.arepl